### PR TITLE
Add pg_db input to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ pg_host: ''
 
 # The port used to connect to the database
 pg_port: 5432
+
+# The name of the database to connect to
+pg_db: ''
 ```
 
 # Running This Baseline Directly from Github


### PR DESCRIPTION
If you don't define this all controls attempt to run on the inherited db named 'stig'